### PR TITLE
Readme kiegészítés -Discordon is lehet jelenteni

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # TheOld - Crafters
 TheOld - Crafters hibajelentések és ötletek:
 Az Issues oldalon a zöld New Issue gombbal lehet bejelenteni a hibákat vagy ötleteket írni.
+
+A Discord szerverünkön is jelenthetsz hibákat és írhatsz ötleteket, ha esetleg nincs GitHub fiókod.


### PR DESCRIPTION
Kiegészíti a Readme fájlt azzal, hogy Discordon is lehet jelenteni hibákat, illetve ötleteket írni. Az elmúlt hónapokban lettek létrehozva külön csatornák ezekre a célokra.

Azért egészíteném ki, mert egy átlagos embernek nagyobb valószínűséggel van Discord fiókja mint GitHub fiókja.

Ha a szöveg nem felel meg, vagy esetleg lehetne még hozzá írni/szerkeszteni rajta kérem jelezzétek nekem.

Megjegyzés: ez az első tényleges Pull Requestem GitHubon, remélem jól sikerült :D